### PR TITLE
style: 修改标准返回的参数命名

### DIFF
--- a/src/main/java/io/github/talelin/merak/common/utils/ResponseUtil.java
+++ b/src/main/java/io/github/talelin/merak/common/utils/ResponseUtil.java
@@ -32,9 +32,9 @@ public class ResponseUtil {
                 .build();
     }
 
-    public static <T> UnifyResponseVO<T> generateUnifyResponse(int errorCode) {
+    public static <T> UnifyResponseVO<T> generateUnifyResponse(int code) {
         return (UnifyResponseVO<T>) UnifyResponseVO.builder()
-                .code(errorCode)
+                .code(code)
                 .request(RequestUtil.getSimpleRequest())
                 .build();
     }


### PR DESCRIPTION
将`io.github.talelin.merak.common.utils.ResponseUtil#generateUnifyResponse(int)` 的参数 `errorCode` 修改为 `code`