### PR TITLE
用户头像为null时，登陆异常

### DIFF
--- a/src/main/java/io/github/talelin/merak/common/interceptor/AuthorizeVerifyResolverImpl.java
+++ b/src/main/java/io/github/talelin/merak/common/interceptor/AuthorizeVerifyResolverImpl.java
@@ -125,9 +125,11 @@ public class AuthorizeVerifyResolverImpl implements AuthorizeVerifyResolver {
             throw new NotFoundException("user is not found", 10021);
         }
         String avatarUrl;
-        if (user.getAvatar().startsWith("http")) {
+        if (user.getAvatar() == null){
+            avatarUrl = null;
+        }else if (user.getAvatar().startsWith("http")) {
             avatarUrl = user.getAvatar();
-        } else {
+        } else{
             avatarUrl = domain + servePath.split("/")[0] + "/" + user.getAvatar();
         }
         user.setAvatar(avatarUrl);


### PR DESCRIPTION
### 问题
修复用户头像为null时，引发的登陆异常
![image](https://user-images.githubusercontent.com/31000104/80086346-24f25b80-858c-11ea-9ecf-5a711e05d629.png)

出现问题的分支：master（0.3.x）

### 问题复位 

在拉下代码到本地时，根据本地数据库配置，修改系统配置文件，然后开启java的http服务，通过lin-cms-vue的页面服务进行后端cms访问，点击登陆就会弹窗提示服务器内部错误，java服务报错内容如下：

- 控制台
```
2020-04-23 17:58:59.574 DEBUG 99852 --- [nio-5000-exec-4] .m.m.a.ExceptionHandlerExceptionResolver : Using @ExceptionHandler io.github.talelin.merak.common.exception.RestExceptionHandler#processException(Exception, HttpServletRequest, HttpServletResponse)
2020-04-23 17:58:59.575 ERROR 99852 --- [nio-5000-exec-4] i.g.t.m.c.e.RestExceptionHandler         : 

java.lang.NullPointerException: null
	at io.github.talelin.merak.common.interceptor.AuthorizeVerifyResolverImpl.getClaim(AuthorizeVerifyResolverImpl.java:128)
	at io.github.talelin.merak.common.interceptor.AuthorizeVerifyResolverImpl.handleLogin(AuthorizeVerifyResolverImpl.java:66)
```

- 错误文件：

`io/github/talelin/merak/common/interceptor/AuthorizeVerifyResolverImpl.java` 第 `128`行

- 错误内容：

![image](https://user-images.githubusercontent.com/31000104/80087150-4ef84d80-858d-11ea-8d75-475417d4a754.png)


### 解决方法

修改代码思想，不修改在数据库默认值的情况下，就通过程序判断，然后设置默认值。

具体代码：


![image](https://user-images.githubusercontent.com/31000104/80087194-5e779680-858d-11ea-99bb-53e30a6350e2.png)

