### PR TITLE
fix: 为数据源账号密码配置添加双引号

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -8,10 +8,10 @@ server:
 spring:
   # 数据源配置，请修改为你项目的实际配置
   datasource:
+    username: "root"
+    password: "123456"
     driver-class-name: com.mysql.cj.jdbc.Driver
-    password: 123456
     url: jdbc:mysql://localhost:3306/lin-cms?useSSL=false&serverTimezone=UTC&characterEncoding=UTF8
-    username: root
 
 
 # 开启权限拦截

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -7,10 +7,10 @@ server:
 spring:
   # 数据源配置，请修改为你项目的实际配置
   datasource:
+    username: "root"
+    password: "123456"
     driver-class-name: com.mysql.cj.jdbc.Driver
-    password: 123456
     url: jdbc:mysql://localhost:3306/lin-cms?useSSL=false&serverTimezone=UTC&characterEncoding=UTF8
-    username: root
 
 # 开启权限拦截
 auth:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -12,13 +12,13 @@ logging:
 spring:
   # h2 内存数据库配置，供测试使用，其它环境勿用
   datasource:
-    continue-on-error: false
-    driver-class-name: org.h2.Driver
+    username: "sa"
     password: ''
     platform: h2
+    continue-on-error: false
     schema: classpath:/h2-test.sql
+    driver-class-name: org.h2.Driver
     url: jdbc:h2:mem:testdbsa;MODE=MYSQL;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false
-    username: sa
   h2:
     console:
       enabled: true


### PR DESCRIPTION
防止数据库密码出现特殊字符与 yaml 不兼容

close #91