### PR TITLE
feat(Logback): 新增日志文件大小限制

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -21,6 +21,8 @@
     <appender name="FILE_ACCESS" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/access/%d{yyyy-MM,aux}/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <totalSizeCap>1GB</totalSizeCap>
+            <maxHistory>30</maxHistory>
             <maxFileSize>5MB</maxFileSize>
         </rollingPolicy>
         <encoder>
@@ -39,6 +41,8 @@
     <appender name="FILE_ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/error/%d{yyyy-MM,aux}/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <totalSizeCap>1GB</totalSizeCap>
+            <maxHistory>30</maxHistory>
             <maxFileSize>5MB</maxFileSize>
         </rollingPolicy>
         <encoder>
@@ -57,6 +61,8 @@
     <appender name="FILE_WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/warn/%d{yyyy-MM,aux}/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <totalSizeCap>1GB</totalSizeCap>
+            <maxHistory>30</maxHistory>
             <maxFileSize>5MB</maxFileSize>
         </rollingPolicy>
         <encoder>
@@ -75,6 +81,8 @@
     <appender name="FILE_INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/info/%d{yyyy-MM,aux}/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <totalSizeCap>1GB</totalSizeCap>
+            <maxHistory>30</maxHistory>
             <maxFileSize>5MB</maxFileSize>
         </rollingPolicy>
         <encoder>
@@ -93,6 +101,8 @@
     <appender name="FILE_DEBUG" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/debug/%d{yyyy-MM,aux}/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <totalSizeCap>1GB</totalSizeCap>
+            <maxHistory>30</maxHistory>
             <maxFileSize>5MB</maxFileSize>
         </rollingPolicy>
         <encoder>
@@ -111,6 +121,8 @@
     <appender name="FILE_TRACE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>logs/trace/%d{yyyy-MM,aux}/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <totalSizeCap>1GB</totalSizeCap>
+            <maxHistory>30</maxHistory>
             <maxFileSize>5MB</maxFileSize>
         </rollingPolicy>
         <encoder>


### PR DESCRIPTION
每个等级日志文件限制最大 1GB