### PR TITLE
Chore/adjust configuration annotation

### DIFF
--- a/src/main/java/io/github/talelin/latticy/common/configuration/CommonConfiguration.java
+++ b/src/main/java/io/github/talelin/latticy/common/configuration/CommonConfiguration.java
@@ -6,19 +6,17 @@ import com.baomidou.mybatisplus.extension.plugins.PaginationInterceptor;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import io.github.talelin.autoconfigure.bean.PermissionMetaCollector;
 import io.github.talelin.latticy.common.interceptor.RequestLogInterceptor;
-import io.github.talelin.latticy.module.file.FileProperties;
 import io.github.talelin.latticy.module.log.MDCAccessServletFilter;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
  * @author pedro@TaleLin
+ * @author colorful@TaleLin
  */
 @Configuration(proxyBeanMethods = false)
-@EnableConfigurationProperties(FileProperties.class)
 public class CommonConfiguration {
 
     @Bean

--- a/src/main/java/io/github/talelin/latticy/extension/file/UploaderConfiguration.java
+++ b/src/main/java/io/github/talelin/latticy/extension/file/UploaderConfiguration.java
@@ -10,8 +10,9 @@ import org.springframework.core.annotation.Order;
  * 文件上传配置类
  *
  * @author Juzi@TaleLin
+ * @author colorful@TaleLin
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 public class UploaderConfiguration {
     /**
      * @return 本地文件上传实现类


### PR DESCRIPTION
1.  `FileProperties` 类已经被 `@Component` + `@ConfigurationProperties` 注解进行了配置绑定，不需要再使用`@EnableAutoConfiguration`注解自动绑定；
2. `UploaderConfiguration` 配置类不依赖任何组件，`@Configuration` 注解可开启 Lite 模式，以加速容器启动过程。