### PR TITLE
bug: getUsers接口无法得到用户权限组

### DIFF
--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -23,7 +23,7 @@
     </select>
 
     <select id="selectPageByGroupId" parameterType="java.lang.Integer" resultMap="BaseResultMap">
-        SELECT u.username, u.nickname,
+        SELECT u.id, u.username, u.nickname,
         u.avatar, u.email, u.create_time,
         u.update_time, u.delete_time
         FROM lin_user AS u


### PR DESCRIPTION
访问getUsers接口带有goupId时，selectPageByGroupId方法没有返回u.id，无法获得用户所属的权限分组
```
  public IPage<UserDO> getUserPageByGroupId(Page<UserDO> pager, Integer groupId) {
        Integer rootGroupId = groupService.getParticularGroupIdByLevel(GroupLevelEnum.ROOT);
        // selectPageByGroupId 没有返回用户id 
        return this.baseMapper.selectPageByGroupId(pager, groupId, rootGroupId);
    }
  // 无法获得用户所属的权限分组
  public List<GroupDO> getUserGroupsByUserId(Integer userId) {
        return this.baseMapper.selectGroupsByUserId(userId);
    }

```