### PR TITLE
fix issue #131

### DIFF
--- a/src/main/java/io/github/talelin/latticy/module/file/AbstractUploader.java
+++ b/src/main/java/io/github/talelin/latticy/module/file/AbstractUploader.java
@@ -18,7 +18,7 @@ import java.util.UUID;
  */
 public abstract class AbstractUploader implements Uploader {
 
-    private PreHandler preHandler;
+    private UploadHandler uploadHandler;
 
     @Override
     public List<File> upload(MultiValueMap<String, MultipartFile> fileMap) {
@@ -29,8 +29,8 @@ public abstract class AbstractUploader implements Uploader {
     }
 
     @Override
-    public List<File> upload(MultiValueMap<String, MultipartFile> fileMap, PreHandler preHandler) {
-        this.preHandler = preHandler;
+    public List<File> upload(MultiValueMap<String, MultipartFile> fileMap, UploadHandler uploadHandler) {
+        this.uploadHandler = uploadHandler;
         return this.upload(fileMap);
     }
 
@@ -64,12 +64,16 @@ public abstract class AbstractUploader implements Uploader {
                 extension(ext).
                 build();
         // 如果预处理器不为空，且处理结果为false，直接返回, 否则处理
-        if (preHandler != null && !preHandler.handle(fileData)) {
+        if (uploadHandler != null && !uploadHandler.preHandle(fileData)) {
             return;
         }
         boolean ok = handleOneFile(bytes, newFilename);
         if (ok) {
             res.add(fileData);
+            // 上传到本地或云上成功之后，调用afterHandle
+            if (uploadHandler != null) {
+                uploadHandler.afterHandle(fileData);
+            }
         }
     }
 

--- a/src/main/java/io/github/talelin/latticy/module/file/UploadHandler.java
+++ b/src/main/java/io/github/talelin/latticy/module/file/UploadHandler.java
@@ -5,12 +5,17 @@ package io.github.talelin.latticy.module.file;
  *
  * @author pedro@TaleLin
  */
-public interface PreHandler {
+public interface UploadHandler {
 
     /**
      * 在文件写入本地或者上传到云之前调用此方法
      *
      * @return 是否上传，若返回false，则不上传
      */
-    boolean handle(File file);
+    boolean preHandle(File file);
+
+    /**
+     * 在文件写入本地或者上传到云之后调用此方法
+     */
+    void afterHandle(File file);
 }

--- a/src/main/java/io/github/talelin/latticy/module/file/Uploader.java
+++ b/src/main/java/io/github/talelin/latticy/module/file/Uploader.java
@@ -24,8 +24,8 @@ public interface Uploader {
      * 上传文件
      *
      * @param fileMap    文件map
-     * @param preHandler 预处理器
+     * @param uploadHandler 预处理器
      * @return 文件数据
      */
-    List<File> upload(MultiValueMap<String, MultipartFile> fileMap, PreHandler preHandler);
+    List<File> upload(MultiValueMap<String, MultipartFile> fileMap, UploadHandler uploadHandler);
 }

--- a/src/main/java/io/github/talelin/latticy/service/impl/FileServiceImpl.java
+++ b/src/main/java/io/github/talelin/latticy/service/impl/FileServiceImpl.java
@@ -4,9 +4,7 @@ import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
 import io.github.talelin.latticy.bo.FileBO;
 import io.github.talelin.latticy.mapper.FileMapper;
 import io.github.talelin.latticy.model.FileDO;
-import io.github.talelin.latticy.module.file.FileConstant;
-import io.github.talelin.latticy.module.file.FileProperties;
-import io.github.talelin.latticy.module.file.Uploader;
+import io.github.talelin.latticy.module.file.*;
 import io.github.talelin.latticy.service.FileService;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,19 +41,29 @@ public class FileServiceImpl extends ServiceImpl<FileMapper, FileDO> implements 
     @Override
     public List<FileBO> upload(MultiValueMap<String, MultipartFile> fileMap) {
         List<FileBO> res = new ArrayList<>();
-        uploader.upload(fileMap, file -> {
-            FileDO found = this.baseMapper.selectByMd5(file.getMd5());
-            // 数据库中不存在
-            if (found == null) {
+
+        uploader.upload(fileMap, new UploadHandler() {
+            @Override
+            public boolean preHandle(File file) {
+                FileDO found = baseMapper.selectByMd5(file.getMd5());
+                // 数据库中不存在，存储操作放在上传到本地或云上之后，
+                // 修复issue131：https://github.com/TaleLin/lin-cms-spring-boot/issues/131
+                if (found == null) {
+                    return true;
+                }
+                // 已存在，则直接转化返回
+                res.add(transformDoToBo(found, file.getKey()));
+                return false;
+            }
+
+            @Override
+            public void afterHandle(File file) {
+                // 保存到数据库, 修复issue131：https://github.com/TaleLin/lin-cms-spring-boot/issues/131
                 FileDO fileDO = new FileDO();
                 BeanUtils.copyProperties(file, fileDO);
-                this.getBaseMapper().insert(fileDO);
+                getBaseMapper().insert(fileDO);
                 res.add(transformDoToBo(fileDO, file.getKey()));
-                return true;
             }
-            // 已存在，则直接转化返回
-            res.add(transformDoToBo(found, file.getKey()));
-            return false;
         });
         return res;
     }


### PR DESCRIPTION
修复文件上传的bug #131 

原理：将PreHandler重命名为UploadHandler，增加afterHandle回调，在文件上传到本地或云上成功之后，再去做存库的操作；重复上传操作和原来一样在preHandle中做判断

分析：开始考虑是加事务解决，但是上传是个比较耗时的操作，无疑会拉长事务的占用时间，是不可取的，
况且上传操作将异常catch了，通过返回boolean告知上传结果，事务也无法捕获，若要强行抛异常加事务也不符合源码的设计理念，因此将存库放到真正上传成功之后，个人觉得是比较合理的做法。

